### PR TITLE
fix: correct spotlight alignment and dropdown clicking issues

### DIFF
--- a/stay_focus_desktop/renderer/overlay.js
+++ b/stay_focus_desktop/renderer/overlay.js
@@ -159,10 +159,20 @@ if (window.electronAPI) {
             h: state.h
           };
           maskClip.style.borderRadius = isWin11 ? '8px' : '0px';
+          maskClip.style.left = `${activeRect.x}px`;
+          maskClip.style.top = `${activeRect.y}px`;
+          maskClip.style.width = `${activeRect.w}px`;
+          maskClip.style.height = `${activeRect.h}px`;
+          maskClip.style.overflow = 'hidden';
         } else {
           // Global mode
           activeRect = { x: 0, y: 0, w: window.innerWidth, h: window.innerHeight };
           maskClip.style.borderRadius = '0px';
+          maskClip.style.left = '0px';
+          maskClip.style.top = '0px';
+          maskClip.style.width = '100vw';
+          maskClip.style.height = '100vh';
+          maskClip.style.overflow = 'hidden';
         }
         autoHideVisible = true;
       } else {

--- a/stay_focus_desktop/renderer/settings.js
+++ b/stay_focus_desktop/renderer/settings.js
@@ -281,6 +281,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   processInput.addEventListener('focus', refreshProcessDropdown);
+  processInput.addEventListener('click', refreshProcessDropdown);
 
   processInput.addEventListener('input', () => {
     const val = processInput.value.trim().toLowerCase();


### PR DESCRIPTION
This PR includes fixes for two recent issues:

1. **Spotlight Alignment:** Fixed the issue where the spotlight was misaligned (appearing at the top-left of the mouse pointer) when "specific processes" mode is enabled and the target process is running in windowed mode. The fix properly styles the mask clip container.
2. **Settings Dropdown:** Fixed the issue where the settings dropdown for adding specific processes would not reappear if you click on the input box repeatedly without blurring it first. A click listener has been added to ensure it pops up effortlessly.